### PR TITLE
fix: npm downloads count

### DIFF
--- a/app/modules/stats/index.tsx
+++ b/app/modules/stats/index.tsx
@@ -111,7 +111,7 @@ async function fetchNpmDownloads() {
       urls.map((url) => fetch(url).then((res) => res.json()))
     );
     const allTimeDownloads = queryData.reduce(
-      (acc, { downloads }) => acc + downloads,
+      (acc, { downloads = 0 }) => acc + downloads,
       0
     );
     return allTimeDownloads;


### PR DESCRIPTION
we got the below error when back to the home page

<img width="513" alt="image" src="https://user-images.githubusercontent.com/3297859/210239260-658cb157-61a6-4b84-aba0-c6a29a9c66a0.png">

the root cause is that the `npmDownloads` is `NaN`

the npm download counts API response

```
query [
  {
    downloads: 1993005,
    start: '2015-01-10',
    end: '2016-01-10',
    package: 'react-router'
  },
  {
    downloads: 9876499,
    start: '2016-01-11',
    end: '2017-01-11',
    package: 'react-router'
  },
  {
    downloads: 28481372,
    start: '2017-01-12',
    end: '2018-01-12',
    package: 'react-router'
  },
  {
    downloads: 62270439,
    start: '2018-01-13',
    end: '2019-01-13',
    package: 'react-router'
  },
  {
    downloads: 127107479,
    start: '2019-01-14',
    end: '2020-01-14',
    package: 'react-router'
  },
  {
    downloads: 184417302,
    start: '2020-01-15',
    end: '2021-01-15',
    package: 'react-router'
  },
  {
    downloads: 250765671,
    start: '2021-01-16',
    end: '2022-01-16',
    package: 'react-router'
  },
  {
    downloads: 417683846,
    start: '2022-01-17',
    end: '2023-01-03',
    package: 'react-router'
  },
  { error: 'end date > start date' }
]
```
