### PR TITLE
fix: stat `count` can be `null`

### DIFF
--- a/app/routes/$lang.$ref/index.tsx
+++ b/app/routes/$lang.$ref/index.tsx
@@ -192,7 +192,7 @@ export default function Index() {
               </svg>
               <p className="flex flex-col">
                 <span className="text-3xl font-light tracking-tight">
-                  {count.toLocaleString("en-US")}
+                  {count?.toLocaleString("en-US")}
                 </span>
                 <span className="text-gray-300 dark:text-gray-500">
                   {label}


### PR DESCRIPTION
Related to https://github.com/remix-run/react-router-website/pull/25