### PR TITLE
fix(routes/brand): fix typo

### DIFF
--- a/app/routes/brand.tsx
+++ b/app/routes/brand.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 
 export function meta() {
   return {
-    title: "React Router Assets and Branding Guidlines",
+    title: "React Router Assets and Branding Guidelines",
   };
 }
 


### PR DESCRIPTION
- revised the spelling of `Guidlines` to `Guidelines` in the brand page metadata
- ran cSpell against the entire repo to check for other misspellings and didn't find any :)