### PR TITLE
fix: readme setup description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Copy the `.env` file and add your information to it.
+Copy the contents of `.env.example` file to the `.env` file and add your information to it.
 
 ```sh
 cp .env.example .env


### PR DESCRIPTION
This PR fixes the setup description in README.md.

Currently, README.md says "Copy the .env" file but while setting up the project we do not have a .env file. Instead, we create .env file and copy the contents of .env.example to it.