### PR TITLE
Update code element's display property

### DIFF
--- a/app/styles.source.css
+++ b/app/styles.source.css
@@ -333,7 +333,7 @@ html.dark {
   }
 
   & pre code {
-    display: inline;
+    display: grid;
     max-width: auto;
     padding: 0;
     margin: 0;

--- a/app/styles.source.css
+++ b/app/styles.source.css
@@ -333,7 +333,7 @@ html.dark {
   }
 
   & pre code {
-    display: grid;
+    display: inline-block;
     max-width: auto;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
Changed the "display" property of the "code" element to "grid" to fix an issue where the green code highlighter ("span" element) did not highlight the entire line of code on mobile or smaller screen devices. The issue was caused by the parent "code" element being inline and not filling up the entire width of its parent "pre" element.

Screenshots of the issue before and after the changes are included for better visualization.

Before:

![dispaly-before-fix-on-mobile-phones](https://user-images.githubusercontent.com/99342564/227962487-94625da2-ae14-4e62-9183-69523ee98c99.png)

After:

![dispaly-after-fix-on-mobile-phones](https://user-images.githubusercontent.com/99342564/227963475-e79edc8d-3184-4090-84de-f26db7dc63a9.png)

This change only affects the "code" element and does not impact any other CSS rules or elements.