### PR TITLE
feat: menu search

### DIFF
--- a/app/modules/gh-docs/index.ts
+++ b/app/modules/gh-docs/index.ts
@@ -6,7 +6,7 @@ import invariant from "tiny-invariant";
 export { validateParams } from "./params";
 export { getRepoTarballStream } from "./repo-tarball.server";
 
-export type { Doc } from "./docs";
+export type { Doc, MenuDoc } from "./docs";
 
 const REPO = process.env.SOURCE_REPO!;
 if (!REPO) throw new Error("Missing process.env.SOURCE_REPO");


### PR DESCRIPTION
## Description
This PR implements a simple menu search for the react-router documentation site. 

### Reason:
- I work at a tech consultancy, and we use react-router quite often across different projects. We often struggle searching through the docs.
- Seems like we're not the only ones who feel this way -> e.g. https://github.com/remix-run/react-router-website/issues/75

## Changes Made
- Refactored `Menu` with a guard clause and for readability
- Extracted the child categories into `MenuCategory`
- Created `Search` component
- Updated types

## Screenshots or GIFs (if applicable)
<img src="https://github.com/remix-run/react-router-website/assets/111836326/d165f705-4d1d-4e15-9b5e-1dcee11eb8f0" alt="menu-search" width="400px" height="220px"/>

## Testing
I see that the codebase currently doesn't test its UI components. So I did not add any for now. Do let me know if we want to add some.

## Additional Notes
Not a lot of code added, but likely a lot of value for the thousands of react router users 😄

Tagging recent contributors and good sirs for review @brophdawg11 @MichaelDeBoey 