### PR TITLE
Add color-scheme:dark when the dark class is applied

### DIFF
--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -34,6 +34,10 @@
   src: url("/font/source-code-pro-italic-var.woff2") format("woff2");
 }
 
+.dark {
+  color-scheme: dark;
+}
+
 ._no-triangle::-webkit-details-marker {
   display: none;
   &::-webkit-details-marker {


### PR DESCRIPTION
Same contribution as we received in [remix-website](https://github.com/remix-run/remix-website/pull/241)

Makes scrollbars and other defaults look a lot better in dark mode

<img width="2560" alt="image" src="https://github.com/remix-run/react-router-website/assets/12396812/2c3b10e0-0f64-4e6e-8180-9b28f2882c15">

