### PR TITLE
Fix overlapping issue

### DIFF
--- a/app/routes/$lang.$ref.$.tsx
+++ b/app/routes/$lang.$ref.$.tsx
@@ -119,7 +119,7 @@ export default function DocPage() {
       ) : (
         <div className="hidden xl:order-1 xl:block xl:w-56 xl:flex-shrink-0" />
       )}
-      <div className="px-4 pb-4 pt-12 lg:ml-72 lg:pl-12 lg:pr-8 xl:flex-grow xl:pt-20">
+      <div className="min-w-0 px-4 pt-12 xl:mr-4 xl:flex-grow xl:pl-0 xl:pt-20">
         <div ref={ref} className="markdown w-full max-w-3xl pb-[33vh]">
           <div
             className="md-prose"
@@ -155,7 +155,7 @@ function LargeOnThisPage({ doc }: { doc: SerializeFrom<Doc> }) {
 
 function SmallOnThisPage({ doc }: { doc: SerializeFrom<Doc> }) {
   return (
-    <details className="group flex h-full flex-col lg:ml-80 lg:mt-4 xl:hidden">
+    <details className="group flex flex-col lg:mt-4 xl:hidden">
       <summary className="_no-triangle flex cursor-pointer select-none items-center gap-2 border-b border-gray-50 bg-white px-2 py-3 text-sm font-medium hover:bg-gray-50 active:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-gray-800 dark:active:bg-gray-700">
         <div className="flex items-center gap-2">
           <svg aria-hidden className="h-5 w-5 group-open:hidden">

--- a/app/routes/$lang.$ref._index.tsx
+++ b/app/routes/$lang.$ref._index.tsx
@@ -171,7 +171,7 @@ export default function Index() {
   let stats = "stats" in loaderData ? loaderData.stats : [];
 
   return (
-    <div className="px-4 pb-4 pt-8 lg:ml-72 lg:pl-12 lg:pr-8">
+    <div className="px-4 pb-4 pt-8 lg:mr-4 xl:pl-0">
       <div className="my-4 grid max-w-[60ch] gap-y-10 md:max-w-none md:grid-cols-2 md:grid-rows-2 md:gap-x-8 md:gap-y-12">
         {mainLinks.map(({ title, description, slug, className, svg }) => (
           <Link

--- a/app/routes/$lang.$ref.tsx
+++ b/app/routes/$lang.$ref.tsx
@@ -89,29 +89,39 @@ export default function DocsLayout() {
     !navigation.location.pathname.match(params.ref);
 
   return (
-    <div className="lg:m-auto lg:max-w-[90rem]">
+    <div className="[--header-height:theme(spacing.16)] [--nav-width:theme(spacing.72)] lg:m-auto lg:max-w-[90rem]">
       <div className="sticky top-0 z-20">
         <Header />
         <NavMenuMobile />
       </div>
       <div
         className={
-          changingVersions ? "opacity-25 transition-opacity delay-300" : ""
+          changingVersions
+            ? "opacity-25 transition-opacity delay-300"
+            : undefined
         }
       >
-        <NavMenuDesktop />
-        <div
-          className={classNames(
-            "min-h-[80vh]",
-            !changingVersions && navigating
-              ? "opacity-25 transition-opacity delay-300"
-              : ""
-          )}
-        >
-          <Outlet />
-        </div>
-        <div className="px-4 pb-4 pt-8 lg:ml-72 lg:pl-12 lg:pr-8">
-          <Footer />
+        <div className="block lg:flex">
+          <NavMenuDesktop />
+          <div
+            className={classNames(
+              // add scroll margin to focused elements so that they aren't
+              // obscured by the sticky header
+              "[&_*:focus]:scroll-mt-[8rem] lg:[&_*:focus]:scroll-mt-[5rem]",
+              // Account for the left navbar
+              "min-h-[80vh] lg:ml-3 lg:w-[calc(100%-var(--nav-width))]",
+              "lg:pl-6 xl:pl-10 2xl:pl-12",
+              !changingVersions && navigating
+                ? "opacity-25 transition-opacity delay-300"
+                : "",
+              "flex flex-col"
+            )}
+          >
+            <Outlet />
+            <div className="mt-auto px-4 pt-8 lg:pr-8 xl:pl-0">
+              <Footer />
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -312,8 +322,16 @@ function HeaderLink({
 
 function NavMenuDesktop() {
   return (
-    <div className="fixed bottom-0 top-16 hidden w-72 overflow-auto py-6 pl-8 pr-6 lg:block">
-      <Menu />
+    <div
+      className={classNames(
+        "sticky bottom-0 top-16 hidden w-[--nav-width] flex-col gap-3 self-start overflow-auto py-6 pl-8 pr-6 lg:flex",
+        // Account for the height of the top nav
+        "h-[calc(100vh-var(--header-height))]"
+      )}
+    >
+      <div className="[&_*:focus]:scroll-mt-[6rem]">
+        <Menu />
+      </div>
     </div>
   );
 }
@@ -684,7 +702,7 @@ function MenuCategoryLink({
 
 function Footer() {
   return (
-    <div className="-ml-8 mt-16 flex justify-between border-t border-t-gray-50 pl-8 pt-4 text-sm text-gray-400 dark:border-gray-800">
+    <div className="flex justify-between gap-4 border-t border-t-gray-50 py-4 text-sm text-gray-400 dark:border-gray-800">
       <div className="lg:flex lg:items-center">
         <div className="pr-4">
           &copy;{" "}


### PR DESCRIPTION
I managed to fix the element overlapping issue (#106), but because I needed to change some elements from block to flex it required some other changes like removing all the `ml-72`s and adjusting the padding. The Remix website source helped a lot on how to do this, and most of these changes come directly from there.

The footer is also slightly different due to the change from block to flex, so no problem if this is not merged because of that. Closest I could get it to working with flex instead of block :)