### PR TITLE
fix: pre/code links don't change color when :active in dark mode

### DIFF
--- a/app/styles/docs.css
+++ b/app/styles/docs.css
@@ -317,7 +317,8 @@
 
   & :is(a, h1, h2, h3, h4, h5, h6) code,
   & :is(a, h1, h2, h3, h4, h5, h6) kbd {
-    @apply text-inherit;
+    /* dark:text-inherit needs to be specified explicitly for the :active color to apply */
+    @apply text-inherit dark:text-inherit;
   }
 
   & :is(h1, h2, h3, h4, h5, h6) code {


### PR DESCRIPTION
...unlike normal links in dark mode, or both types of links in light mode.

| Inline code link, before (hover & active) | Inline code link, after (hover & active) |
|-|-|
| ![20240602T052818+0900](https://github.com/remix-run/react-router-website/assets/11722318/69f9cbf5-c244-4e91-9c56-a6314b748258) | ![20240602T052748+0900](https://github.com/remix-run/react-router-website/assets/11722318/2b5f3b0b-5a71-44ca-82eb-8c36818fd767) |

| Normal link (hover & active) | Inline code link, light mode (hover & active) |
|-|-|
| ![20240602T052843+0900](https://github.com/remix-run/react-router-website/assets/11722318/5a63b153-7428-445a-a9fc-93804bbcf3e7) | ![20240602T053409+0900](https://github.com/remix-run/react-router-website/assets/11722318/3fc155e5-8670-4009-adf6-05a4fea6579f) |


(Test page: [route/route](https://reactrouter.com/en/main/route/route))


This is the same issue as <https://github.com/remix-run/remix-website/pull/262>: the dark mode plain color rule has higher specificity than the text-inherit rule, so dark:inherit is needed to allow the :active color to continue to be applied. In this case it is more subtle (which is why I initially though there is no problem here), as links are still distinguishable as links.