### PR TITLE
api docs perf improvement

### DIFF
--- a/app/components/docs-menu/data.server.ts
+++ b/app/components/docs-menu/data.server.ts
@@ -11,25 +11,20 @@ export async function loadGuidesMenu(ref: string) {
   return getRepoDocsMenu(ref, "en");
 }
 
-export async function loadReferenceMenu(ref: string, pkg: string) {
+export type Pkg = Awaited<ReturnType<typeof loadPackageData>>["pkgs"][number];
+
+export async function loadPackageData(ref: string, pkg: string) {
   let menu = await getRepoDocsReferenceMenu(ref);
+
   let pkgName = pkg === "react-router" ? pkg : `@react-router/${pkg}`;
   let pkgMenu = menu.find((p) => p.attrs.title === pkgName);
   if (!pkgMenu) throw new Response("Not Found", { status: 404 });
-  return pkgMenu.children;
-}
 
-export type Pkg = {
-  name: string;
-  href: any;
-};
-
-export async function loadPackageNames(ref: string): Promise<Pkg[]> {
-  let menu = await getRepoDocsReferenceMenu(ref);
-  return menu.map((pkg) => {
-    return {
-      name: pkg.attrs.title,
-      href: pkg.attrs.href,
-    };
-  });
+  return {
+    pkgs: menu.map(({ attrs }) => ({
+      name: attrs.title,
+      href: attrs.href,
+    })),
+    menu: pkgMenu.children,
+  };
 }

--- a/app/pages/api-layout.tsx
+++ b/app/pages/api-layout.tsx
@@ -8,10 +8,7 @@ import { getHeaderData } from "~/components/docs-header/data.server";
 import { Footer } from "~/components/docs-footer";
 import { NavMenuDesktop } from "~/components/docs-menu/menu-desktop";
 import { NavMenuMobile } from "~/components/docs-menu/menu-mobile";
-import {
-  loadPackageNames,
-  loadReferenceMenu,
-} from "~/components/docs-menu/data.server";
+import { loadPackageData } from "~/components/docs-menu/data.server";
 import { PackageSelect } from "~/components/package-select";
 import { Menu } from "~/components/docs-menu/menu";
 
@@ -25,13 +22,12 @@ export let loader = async ({ params }: LoaderFunctionArgs) => {
   let { ref, pkg } = params;
   invariant(pkg, `Expected params.pkg`);
 
-  let [menu, header, pkgs] = await Promise.all([
-    loadReferenceMenu(ref || "main", pkg),
+  let [packageData, header] = await Promise.all([
+    loadPackageData(ref || "main", pkg),
     getHeaderData("en", ref),
-    loadPackageNames(ref || "main"),
   ]);
 
-  return { menu, header, pkgs };
+  return { header, ...packageData };
 };
 
 export default function DocsLayout() {


### PR DESCRIPTION
Trying to root out perf issues with the api routes. The following is based on averages of 10 trials

**Setup**

- run `NO_CACHE=1 npm run dev`
- Disable Cache in chrome dev tools
- Go to http://localhost:3000/dev/api/react-router

**Results**

| Loader           | Before (ms) | After (ms) |
| ---------------- | ----------- | ---------- |
| `api-layout.tsx` | 735.80      | 380.338    |

