### PR TITLE
Add `shouldRevalidate` to api and guides layout

### DIFF
--- a/app/pages/api-layout.tsx
+++ b/app/pages/api-layout.tsx
@@ -1,5 +1,9 @@
 import invariant from "tiny-invariant";
-import { Outlet, useLoaderData } from "@remix-run/react";
+import {
+  type ShouldRevalidateFunction,
+  Outlet,
+  useLoaderData,
+} from "@remix-run/react";
 import classNames from "classnames";
 
 import docsStylesheet from "~/styles/docs.css?url";
@@ -28,6 +32,12 @@ export let loader = async ({ params }: LoaderFunctionArgs) => {
   ]);
 
   return { header, ...packageData };
+};
+
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  defaultShouldRevalidate,
+}) => {
+  return defaultShouldRevalidate;
 };
 
 export default function DocsLayout() {

--- a/app/pages/guides-layout.tsx
+++ b/app/pages/guides-layout.tsx
@@ -1,5 +1,5 @@
 import type { LinksFunction, LoaderFunctionArgs } from "@remix-run/node";
-import { Outlet } from "@remix-run/react";
+import { type ShouldRevalidateFunction, Outlet } from "@remix-run/react";
 import classNames from "classnames";
 
 import docsStylesheet from "~/styles/docs.css?url";
@@ -24,6 +24,12 @@ export let loader = async ({ params }: LoaderFunctionArgs) => {
   ]);
 
   return { menu, header };
+};
+
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  defaultShouldRevalidate,
+}) => {
+  return defaultShouldRevalidate;
 };
 
 export default function DocsLayout() {


### PR DESCRIPTION
Adding `shouldRevalidate` with `defaultShouldRevalidate` returned from the layout routes, which avoids needless and expensive reconstruction of the API menu 


https://github.com/user-attachments/assets/f9ce6eca-8ef5-4b5c-8f6c-df18155bf405

