### PR TITLE
fix: ensure click-to-copy buttons are created after hydration

### DIFF
--- a/app/ui/utils.ts
+++ b/app/ui/utils.ts
@@ -1,4 +1,3 @@
-import { useLocation } from "react-router";
 import { useEffect, useState } from "react";
 
 let hydrating = true;
@@ -15,7 +14,6 @@ export function useHydrated() {
 export function useCodeBlockCopyButton(
   ref: React.RefObject<HTMLElement | null>
 ) {
-  let location = useLocation();
   useEffect(() => {
     let container = ref.current;
     if (!container) return;
@@ -72,5 +70,5 @@ export function useCodeBlockCopyButton(
         window.clearTimeout(props.to);
       }
     };
-  }, [ref, location.pathname]);
+  });
 }


### PR DESCRIPTION
## Problem

I noticed a bug where the code blocks click-to-copy buttons aren't available on the initial page load or after a page refresh.
The buttons became available again after the next navigation event.

https://github.com/user-attachments/assets/2194b18d-a597-48ab-94ca-ec8e5cdf4230

I couldn't figure out the exact cause of the issue, but I suspect that it has to do with hydration. The markup is overridden after the effect responsible for creating the buttons runs.

In my investigation, I referred to the code for the Remix documentation website ([here](https://github.com/remix-run/remix-website/blob/main/app/routes/docs.%24lang.%24ref.tsx#L916)), which shares a similar implementation, but I am unsure why it's not an issue there.

## Solution

Because I couldn't pinpoint the exact problem, I decided to remove the effect dependencies to ensure it runs with every render. Since the effect manipulates the DOM outside of React, it might be a good idea to re-run it every time anyway.

https://github.com/user-attachments/assets/846c5deb-76d4-406e-bd20-e702bbc62d6d

I did try using the `useHydrated` hook (in the same file) to ensure the hook runs after hydration, but that didn't work.