### PR TITLE
correct alt text of react router logo from nine dots to six

### DIFF
--- a/app/components/docs-header/docs-header.tsx
+++ b/app/components/docs-header/docs-header.tsx
@@ -36,7 +36,7 @@ function LogoLink() {
       }}
     >
       <svg
-        aria-label="React Router logo, nine dots in an upward triangle (one on top, two in the middle, three on the bottom) with a path of three highlighted and connected from top to bottom, next to the text React Router"
+        aria-label="React Router logo, six dots in an upward triangle (one on top, two in the middle, three on the bottom) with a path of three highlighted and connected from top to bottom, next to the text React Router"
         className="h-14 w-40"
       >
         <use href={`${iconsHref}#logo`} />

--- a/app/pages/splash.tsx
+++ b/app/pages/splash.tsx
@@ -121,7 +121,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
             />
             <img
               src="/splash/hero-3d-logo.webp"
-              alt="React Router logo, nine dots in an upward triangle (one on top, two in the middle, three on the bottom) with a path of three highlighted and connected from top to bottom, next to the text React Router"
+              alt="React Router logo, six dots in an upward triangle (one on top, two in the middle, three on the bottom) with a path of three highlighted and connected from top to bottom, next to the text React Router"
               className="aspect-[32/5] w-[360px] md:w-[480px] lg:w-[640px] 2xl:w-[960px]"
             />
           </picture>


### PR DESCRIPTION
as the title says, tiny pr that fixes the alt text for two instances of the react router logo on the website. changes it from nine to six dots