### PR TITLE
Add Shopify.com link and update copyright year to 2025

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) React Training LLC 2015-2021  
-Copyright (c) Shopify Inc. 2022-2023
+Copyright (c) Shopify Inc. 2022-2025
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/pages/splash.tsx
+++ b/app/pages/splash.tsx
@@ -233,8 +233,10 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         </Suspense>
       </section>
       <section className="grid h-[205px] w-full place-content-center place-items-center gap-y-6 bg-gray-50 p-12 dark:bg-black">
-        <img src="/splash/shopify-badge.svg" className="h-[68px] w-[190px]" />
-        <p className="text-sm text-gray-400">© 2024 Shopify, Inc.</p>
+        <a href="https://shopify.com" target="_blank" rel="noopener noreferrer">
+          <img src="/splash/shopify-badge.svg" alt="Developed by Shopify" className="h-[68px] w-[190px]" />
+        </a>
+        <p className="text-sm text-gray-400">© 2025 Shopify, Inc.</p>
       </section>
     </main>
   );

--- a/app/pages/splash.tsx
+++ b/app/pages/splash.tsx
@@ -236,7 +236,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         <a href="https://shopify.com" target="_blank" rel="noopener noreferrer">
           <img src="/splash/shopify-badge.svg" alt="Developed by Shopify" className="h-[68px] w-[190px]" />
         </a>
-        <p className="text-sm text-gray-400">© 2025 Shopify, Inc.</p>
+        <p className="text-sm text-gray-400">© {new Date().getFullYear()} Shopify, Inc.</p>
       </section>
     </main>
   );


### PR DESCRIPTION
This PR makes the following changes:

1. Adds a link to shopify.com around the Shopify logo in the splash page footer
2. Updates the copyright year to 2025 in the splash page footer
3. Updates the copyright year to 2025 in LICENSE.md

These changes are good for SEO attribution and maintain accurate copyright information across the project.

I've followed the contributor guidelines by:
- Forking and cloning the repo
- Creating a branch for these changes
- Pushing the changes to my branch
- Opening this PR in the main repository

## Testing
Ran locally:
https://screenshot.click/15-14-x8s2l-epnh5.mp4