### PR TITLE
Fix "On this page" section clipping outside viewport

### DIFF
--- a/app/components/on-this-page.tsx
+++ b/app/components/on-this-page.tsx
@@ -49,7 +49,7 @@ export function LargeOnThisPage({
   }, [mdRef]);
 
   return (
-    <div className="max-h-[calc(100vh-9rem)] overflow-y-auto">
+    <div className="max-h-[calc(100vh-10.625rem)] overflow-y-auto">
       <nav className="mb-3 flex items-center font-semibold">On this page</nav>
       <ul className="md-toc flex flex-col flex-wrap gap-3 leading-[1.125]">
         {doc.headings.map((heading, i) => (


### PR DESCRIPTION
Currently in the docs, the "On this page" section clips to the bottom of the viewport if there's enough content inside, making the last item on the list inaccessible by scrolling unless you scroll all the way to the bottom of the actual page. This could potentially be improved for better maintenance by introducing a hard-defined height for the "Copy page" button and calculating the section height with it (seeing as how there's already a variable for the header height), but for now this fix should do the job.

<img width="160" height="412" alt="изображение" src="https://github.com/user-attachments/assets/2e33f4c6-3bfa-4e99-af02-cc673434bd3a" />
