### PR TITLE
Bump docsearch deps

### DIFF
--- a/app/modules/docsearch.tsx
+++ b/app/modules/docsearch.tsx
@@ -39,6 +39,7 @@ const DocSearchContext = createContext<{
 export function DocSearch({ children }: { children: React.ReactNode }) {
   const searchButtonRef = useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [isAskAiActive, setIsAskAiActive] = useState(false);
 
   const onOpen = useCallback(() => {
     setIsOpen(true);
@@ -52,13 +53,18 @@ export function DocSearch({ children }: { children: React.ReactNode }) {
     setIsOpen(true);
   }, [setIsOpen]);
 
+  const onAskAiToggle = useCallback((toggle: boolean) => {
+    setIsAskAiActive(toggle);
+  }, []);
+
   useDocSearchKeyboardEvents({
     isOpen,
     onOpen,
     onClose,
     onInput,
-    // @ts-expect-error docsearch types are not updated for react 19
     searchButtonRef,
+    isAskAiActive,
+    onAskAiToggle,
   });
 
   const contextValue = useMemo(
@@ -80,6 +86,8 @@ export function DocSearch({ children }: { children: React.ReactNode }) {
             <OriginalDocSearchModal
               initialScrollY={window.scrollY}
               onClose={onClose}
+              onAskAiToggle={onAskAiToggle}
+              isAskAiActive={isAskAiActive}
               // NOTE: to use the facet for search, it has to be set in the algolia dashboard:
               // "Configuration" > "Filtering and Faceting" > "Facets"
               searchParameters={{

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "name": "react-router-website",
       "dependencies": {
-        "@docsearch/css": "^3.8.3",
-        "@docsearch/react": "^3.8.3",
+        "@docsearch/css": "^4.6.0",
+        "@docsearch/react": "^4.6.0",
         "@react-router/express": "7.12.0",
         "@react-router/node": "7.12.0",
         "@remix-run/tar-parser": "^0.7.0",
@@ -91,228 +91,35 @@
       "license": "MIT"
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
-      "integrity": "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.17.9",
-        "@algolia/autocomplete-shared": "1.17.9"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+        "@algolia/autocomplete-shared": "1.19.2"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.9.tgz",
-      "integrity": "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.17.9"
+        "@algolia/autocomplete-shared": "1.19.2"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
-    "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.9.tgz",
-      "integrity": "sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/autocomplete-shared": "1.17.9"
-      },
-      "peerDependencies": {
-        "@algolia/client-search": ">= 4.9.1 < 6",
-        "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
-      "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
-      }
-    },
-    "node_modules/@algolia/client-abtesting": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.15.0.tgz",
-      "integrity": "sha512-FaEM40iuiv1mAipYyiptP4EyxkJ8qHfowCpEeusdHUC4C7spATJYArD2rX3AxkVeREkDIgYEOuXcwKUbDCr7Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-analytics": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.15.0.tgz",
-      "integrity": "sha512-lho0gTFsQDIdCwyUKTtMuf9nCLwq9jOGlLGIeQGKDxXF7HbiAysFIu5QW/iQr1LzMgDyM9NH7K98KY+BiIFriQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-common": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.15.0.tgz",
-      "integrity": "sha512-IofrVh213VLsDkPoSKMeM9Dshrv28jhDlBDLRcVJQvlL8pzue7PEB1EZ4UoJFYS3NSn7JOcJ/V+olRQzXlJj1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-insights": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.15.0.tgz",
-      "integrity": "sha512-bDDEQGfFidDi0UQUCbxXOCdphbVAgbVmxvaV75cypBTQkJ+ABx/Npw7LkFGw1FsoVrttlrrQbwjvUB6mLVKs/w==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-personalization": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.15.0.tgz",
-      "integrity": "sha512-LfaZqLUWxdYFq44QrasCDED5bSYOswpQjSiIL7Q5fYlefAAUO95PzBPKCfUhSwhb4rKxigHfDkd81AvEicIEoA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.15.0.tgz",
-      "integrity": "sha512-wu8GVluiZ5+il8WIRsGKu8VxMK9dAlr225h878GGtpTL6VBvwyJvAyLdZsfFIpY0iN++jiNb31q2C1PlPL+n/A==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/client-search": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.15.0.tgz",
-      "integrity": "sha512-Z32gEMrRRpEta5UqVQA612sLdoqY3AovvUPClDfMxYrbdDAebmGDVPtSogUba1FZ4pP5dx20D3OV3reogLKsRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/ingestion": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.15.0.tgz",
-      "integrity": "sha512-MkqkAxBQxtQ5if/EX2IPqFA7LothghVyvPoRNA/meS2AW2qkHwcxjuiBxv4H6mnAVEPfJlhu9rkdVz9LgCBgJg==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/monitoring": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.15.0.tgz",
-      "integrity": "sha512-QPrFnnGLMMdRa8t/4bs7XilPYnoUXDY8PMQJ1sf9ZFwhUysYYhQNX34/enoO0LBjpoOY6rLpha39YQEFbzgKyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/recommend": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.15.0.tgz",
-      "integrity": "sha512-5eupMwSqMLDObgSMF0XG958zR6GJP3f7jHDQ3/WlzCM9/YIJiWIUoJFGsko9GYsA5xbLDHE/PhWtq4chcCdaGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.15.0.tgz",
-      "integrity": "sha512-Po/GNib6QKruC3XE+WKP1HwVSfCDaZcXu48kD+gwmtDlqHWKc7Bq9lrS0sNZ456rfCKhXksOmMfUs4wRM/Y96w==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-fetch": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.15.0.tgz",
-      "integrity": "sha512-rOZ+c0P7ajmccAvpeeNrUmEKoliYFL8aOR5qGW5pFq3oj3Iept7Y5mEtEsOBYsRt6qLnaXn4zUKf+N8nvJpcIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/@algolia/requester-node-http": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.15.0.tgz",
-      "integrity": "sha512-b1jTpbFf9LnQHEJP5ddDJKE2sAlhYd7EVSOWgzo/27n/SfCoHfqD0VWntnWYD83PnOKvfe8auZ2+xCb0TXotrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-common": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -864,27 +671,48 @@
         "node": ">=18"
       }
     },
+    "node_modules/@docsearch/core": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.0.tgz",
+      "integrity": "sha512-IqG3oSd529jVRQ4dWZQKwZwQLVd//bWJTz2HiL0LkiHrI4U/vLrBasKB7lwQB/69nBAcCgs3TmudxTZSLH/ZQg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docsearch/css": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.3.tgz",
-      "integrity": "sha512-1nELpMV40JDLJ6rpVVFX48R1jsBFIQ6RnEQDsLFGmzOjPWTOMlZqUcXcvRx8VmYV/TqnS1l784Ofz+ZEb+wEOQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.0.tgz",
+      "integrity": "sha512-YlcAimkXclvqta47g47efzCM5CFxDwv2ClkDfEs/fC/Ak0OxPH2b3czwa4o8O1TRBf+ujFF2RiUwszz2fPVNJQ==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.3.tgz",
-      "integrity": "sha512-6UNrg88K7lJWmuS6zFPL/xgL+n326qXqZ7Ybyy4E8P/6Rcblk3GE8RXxeol4Pd5pFpKMhOhBhzABKKwHtbJCIg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-j8H5B4ArGxBPBWvw3X0J0Rm/Pjv2JDa2rV5OE0DLTp5oiBCptIJ/YlNOhZxuzbO2nwge+o3Z52nJRi3hryK9cA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.17.9",
-        "@algolia/autocomplete-preset-algolia": "1.17.9",
-        "@docsearch/css": "3.8.3",
-        "algoliasearch": "^5.14.2"
+        "@algolia/autocomplete-core": "1.19.2",
+        "@docsearch/core": "4.6.0",
+        "@docsearch/css": "4.6.0"
       },
       "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 19.0.0",
-        "react": ">= 16.8.0 < 19.0.0",
-        "react-dom": ">= 16.8.0 < 19.0.0",
+        "@types/react": ">= 16.8.0 < 20.0.0",
+        "react": ">= 16.8.0 < 20.0.0",
+        "react-dom": ">= 16.8.0 < 20.0.0",
         "search-insights": ">= 1 < 3"
       },
       "peerDependenciesMeta": {
@@ -3014,30 +2842,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/algoliasearch": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.15.0.tgz",
-      "integrity": "sha512-Yf3Swz1s63hjvBVZ/9f2P1Uu48GjmjCN+Esxb6MAONMGtZB1fRX8/S1AhUTtsuTlcGovbYLxpHgc7wEzstDZBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-abtesting": "5.15.0",
-        "@algolia/client-analytics": "5.15.0",
-        "@algolia/client-common": "5.15.0",
-        "@algolia/client-insights": "5.15.0",
-        "@algolia/client-personalization": "5.15.0",
-        "@algolia/client-query-suggestions": "5.15.0",
-        "@algolia/client-search": "5.15.0",
-        "@algolia/ingestion": "1.15.0",
-        "@algolia/monitoring": "1.15.0",
-        "@algolia/recommend": "5.15.0",
-        "@algolia/requester-browser-xhr": "5.15.0",
-        "@algolia/requester-fetch": "5.15.0",
-        "@algolia/requester-node-http": "5.15.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
       }
     },
     "node_modules/ansi-escapes": {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "push:stage": "git tag -f stage && git push origin stage -f"
   },
   "dependencies": {
-    "@docsearch/css": "^3.8.3",
-    "@docsearch/react": "^3.8.3",
+    "@docsearch/css": "^4.6.0",
+    "@docsearch/react": "^4.6.0",
     "@react-router/express": "7.12.0",
     "@react-router/node": "7.12.0",
     "@remix-run/tar-parser": "^0.7.0",


### PR DESCRIPTION
## Summary
- upgrade `@docsearch/react` and `@docsearch/css` to v4
- update the custom DocSearch wrapper to satisfy the new Ask AI toggle props introduced by the latest DocSearch types
- verify the site still typechecks, tests, and builds with the new search bundle

## Verification
- npm run typecheck
- npm run lint
- npm run test -- --run
- npm run build