### PR TITLE
Bump lru-cache

### DIFF
--- a/app/modules/gh-docs/.server/branches.ts
+++ b/app/modules/gh-docs/.server/branches.ts
@@ -1,4 +1,4 @@
-import LRUCache from "lru-cache";
+import { LRUCache } from "lru-cache";
 import { octokit } from "./github";
 
 /**
@@ -18,7 +18,7 @@ global.branchesCache ??= new LRUCache<string, string[]>({
   ttl: 1000 * 60 * 5, // 5 minutes, so we can see new tags quickly
   allowStale: true,
   noDeleteOnFetchRejection: true,
-  fetchMethod: async (key) => {
+  fetchMethod: async (key: string) => {
     console.log("Fetching fresh branches", key);
     let [owner, repo] = key.split("/");
     const { data } = await octokit.rest.repos.listBranches({

--- a/app/modules/gh-docs/.server/docs.ts
+++ b/app/modules/gh-docs/.server/docs.ts
@@ -1,5 +1,5 @@
 import { processMarkdown } from "~/modules/gh-docs/.server/md";
-import LRUCache from "lru-cache";
+import { LRUCache } from "lru-cache";
 import parseYamlHeader from "gray-matter";
 import invariant from "tiny-invariant";
 import { getRepoContent } from "./repo-content";
@@ -44,7 +44,7 @@ export interface Doc extends Omit<MenuDoc, "hasContent"> {
 
 declare global {
   var menuCache: LRUCache<string, MenuDoc[]>;
-  var docCache: LRUCache<string, Doc | undefined>;
+  var docCache: LRUCache<string, Doc>;
 }
 
 let NO_CACHE = process.env.NO_CACHE;
@@ -55,7 +55,7 @@ global.menuCache ??= new LRUCache<string, MenuDoc[]>({
   ttl: NO_CACHE ? 1 : 300000, // 5 minutes
   allowStale: !NO_CACHE,
   noDeleteOnFetchRejection: true,
-  fetchMethod: async (cacheKey) => {
+  fetchMethod: async (cacheKey: string) => {
     console.log(`Fetching fresh menu: ${cacheKey}`);
     let [repo, ref] = cacheKey.split(":");
     let tarball = await getRepoTarball(repo, ref);
@@ -92,7 +92,7 @@ function parseAttrs(
  * let's have simpler and faster deployments with just one origin server, but
  * still distribute the documents across the CDN.
  */
-global.docCache ??= new LRUCache<string, Doc | undefined>({
+global.docCache ??= new LRUCache<string, Doc>({
   max: 300,
   ttl: NO_CACHE ? 1 : 1000 * 60 * 5, // 5 minutes
   allowStale: !NO_CACHE,

--- a/app/modules/gh-docs/.server/tags.ts
+++ b/app/modules/gh-docs/.server/tags.ts
@@ -1,4 +1,4 @@
-import LRUCache from "lru-cache";
+import { LRUCache } from "lru-cache";
 import parseLinkHeader from "parse-link-header";
 import semver from "semver";
 import { octokit } from "./github";
@@ -37,7 +37,7 @@ global.tagsCache ??= new LRUCache<string, string[]>({
   ttl: 1000 * 60 * 5, // 5 minutes, so we can see new tags quickly
   allowStale: true,
   noDeleteOnFetchRejection: true,
-  fetchMethod: async (key) => {
+  fetchMethod: async (key: string) => {
     console.log("Fetching fresh tags (releases)");
     let [owner, repo] = key.split("/");
     return getAllReleases(owner, repo, "react-router");

--- a/app/modules/stats/index.tsx
+++ b/app/modules/stats/index.tsx
@@ -1,4 +1,4 @@
-import LRUCache from "lru-cache";
+import { LRUCache } from "lru-cache";
 import { octokit } from "../gh-docs/.server/github";
 
 export interface Stats {
@@ -46,6 +46,10 @@ global.statCountsCache ??= new LRUCache<string, StatCounts>({
 export async function getStats(): Promise<Stats[]> {
   let cacheKey = "ONE_STATS_KEY_TO_RULE_THEM_ALL";
   let statCounts = await statCountsCache.fetch(cacheKey);
+
+  if (!statCounts) {
+    throw new Error("Could not load stats");
+  }
 
   return [
     {

--- a/app/pages/redirect-major-version.tsx
+++ b/app/pages/redirect-major-version.tsx
@@ -7,7 +7,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   let url = new URL(request.url);
   let [, s, ...rest] = url.pathname.split("/");
 
-  let versions = await getRepoTags();
+  let versions = (await getRepoTags()) ?? [];
   let latest = semver.maxSatisfying(versions, `${s}.x`, {
     includePrerelease: false,
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "hast-util-to-html": "^9.0.5",
         "isbot": "^5.1.31",
         "lodash.merge": "^4.6.2",
-        "lru-cache": "^7.18.3",
+        "lru-cache": "^11.2.6",
         "mdast": "^2.3.2",
         "morgan": "^1.10.1",
         "octokit": "^2.0.14",
@@ -6774,12 +6774,12 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=12"
+        "node": "20 || >=22"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "hast-util-to-html": "^9.0.5",
     "isbot": "^5.1.31",
     "lodash.merge": "^4.6.2",
-    "lru-cache": "^7.18.3",
+    "lru-cache": "^11.2.6",
     "mdast": "^2.3.2",
     "morgan": "^1.10.1",
     "octokit": "^2.0.14",


### PR DESCRIPTION
## Summary
- upgrade `lru-cache` from v7 to v11 for the docs and stats caches
- switch cache imports to the package's named `LRUCache` export and tighten a couple of cache-related types that surfaced during the upgrade
- verify the cache-backed docs flows still typecheck, test, and build cleanly

## Verification
- npm run typecheck
- npm run lint
- npm run test -- --run
- npm run build