### PR TITLE
Bump dotenv-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "autoprefixer": "^10.4.21",
         "cross-env": "^10.0.0",
         "cssnano": "^6.1.1",
-        "dotenv-cli": "^10.0.0",
+        "dotenv-cli": "^11.0.0",
         "happy-dom": "^18.0.1",
         "oxlint": "^1.18.0",
         "postcss": "^8.5.6",
@@ -4667,15 +4667,15 @@
       }
     },
     "node_modules/dotenv-cli": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-10.0.0.tgz",
-      "integrity": "sha512-lnOnttzfrzkRx2echxJHQRB6vOAMSCzzZg79IxpC00tU42wZPuZkQxNNrrwVAxaQZIIh001l4PxVlCrBxngBzA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-11.0.0.tgz",
+      "integrity": "sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "dotenv": "^17.1.0",
-        "dotenv-expand": "^11.0.0",
+        "dotenv-expand": "^12.0.0",
         "minimist": "^1.2.6"
       },
       "bin": {
@@ -4683,9 +4683,9 @@
       }
     },
     "node_modules/dotenv-expand": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "autoprefixer": "^10.4.21",
     "cross-env": "^10.0.0",
     "cssnano": "^6.1.1",
-    "dotenv-cli": "^10.0.0",
+    "dotenv-cli": "^11.0.0",
     "happy-dom": "^18.0.1",
     "oxlint": "^1.18.0",
     "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary
- upgrade `dotenv-cli` to v11 for the local `preview` script
- refresh the lockfile for the new CLI dependency tree without changing runtime app code
- verify the project still typechecks, lints, tests, and builds after the script tooling update

## Verification
- npm run typecheck
- npm run lint
- npm run test -- --run
- npm run build