### PR TITLE
fix: pass lint fix flag through pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "react-router build",
     "format": "prettier --write . && pnpm run lint:fix",
     "lint": "oxlint",
-    "lint:fix": "pnpm run lint -- --fix",
+    "lint:fix": "pnpm run lint --fix",
     "start": "node server.js",
     "preview": "cross-env NODE_ENV=production dotenv node server.js",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- switch the `lint:fix` script to pnpm's correct argument forwarding syntax
- prevent the `👔 Format` workflow from failing when it runs `pnpm run format` on `main`
- keep the PR scoped to the package script change only

## Test plan
- [x] reproduce the failure from commit `90664dd` in a clean worktree
- [x] run `pnpm install --frozen-lockfile`
- [x] run `pnpm run format`