### PR TITLE
Show edit link on latest docs

### DIFF
--- a/app/components/docs-header/data.server.ts
+++ b/app/components/docs-header/data.server.ts
@@ -1,4 +1,3 @@
-import { getRepoTags } from "~/modules/gh-docs/.server";
 import {
   getLatestV6Version,
   getLatestVersion,
@@ -6,14 +5,13 @@ import {
 
 export type HeaderData = Awaited<ReturnType<typeof getHeaderData>>;
 
-export async function getHeaderData(
+export function getHeaderData(
   lang: string,
   ref: string,
+  tags: string[],
   refParam?: string,
 ) {
   let githubRef = ref;
-  let tags = await getRepoTags();
-  if (!tags) throw new Response("Cannot reach GitHub", { status: 503 });
 
   let branchesInMenu = [
     "main",
@@ -21,6 +19,7 @@ export async function getHeaderData(
   ];
 
   let latestVersion = getLatestVersion(tags);
+  let latestV6Version = getLatestV6Version(tags);
   let isLatest = githubRef === latestVersion;
 
   let hasAPIDocs =
@@ -31,8 +30,6 @@ export async function getHeaderData(
 
   // TODO: make this smarter before v8
   let apiDocsRef = "v7";
-
-  let latestV6Version = getLatestV6Version(tags);
 
   // Set the version for docsearch to use as a facet filter so that the search
   // results are context aware

--- a/app/modules/gh-docs/.server/doc-url-parser.test.ts
+++ b/app/modules/gh-docs/.server/doc-url-parser.test.ts
@@ -60,10 +60,14 @@ describe("buildDocPaths", () => {
   describe("default ref (latest tag)", () => {
     it("builds a basic doc page", () => {
       expect(
-        buildDocPaths("/start/modes", "start/modes", LATEST, undefined),
+        buildDocPaths("/start/modes", "start/modes", LATEST, undefined, {
+          editRef: "main",
+        }),
       ).toEqual({
         slug: "docs/start/modes",
         githubPath: `https://raw.githubusercontent.com/remix-run/react-router/refs/tags/react-router@${LATEST}/docs/start/modes.md`,
+        githubEditPath:
+          "https://github.com/remix-run/react-router/edit/main/docs/start/modes.md",
       });
     });
 
@@ -74,42 +78,65 @@ describe("buildDocPaths", () => {
           "getting-started.md",
           LATEST,
           undefined,
+          { editRef: "main" },
         ),
       ).toEqual({
         slug: "docs/getting-started",
         githubPath: `https://raw.githubusercontent.com/remix-run/react-router/refs/tags/react-router@${LATEST}/docs/getting-started.md`,
+        githubEditPath:
+          "https://github.com/remix-run/react-router/edit/main/docs/getting-started.md",
       });
     });
 
     it("detects /home", () => {
-      expect(buildDocPaths("/home", "home", LATEST, undefined)).toEqual({
+      expect(
+        buildDocPaths("/home", "home", LATEST, undefined, {
+          editRef: "main",
+        }),
+      ).toEqual({
         slug: "docs/index",
         githubPath: `https://raw.githubusercontent.com/remix-run/react-router/refs/tags/react-router@${LATEST}/docs/index.md`,
+        githubEditPath:
+          "https://github.com/remix-run/react-router/edit/main/docs/index.md",
       });
     });
 
     it("detects /home.md", () => {
-      expect(buildDocPaths("/home.md", "home.md", LATEST, undefined)).toEqual({
+      expect(
+        buildDocPaths("/home.md", "home.md", LATEST, undefined, {
+          editRef: "main",
+        }),
+      ).toEqual({
         slug: "docs/index",
         githubPath: `https://raw.githubusercontent.com/remix-run/react-router/refs/tags/react-router@${LATEST}/docs/index.md`,
+        githubEditPath:
+          "https://github.com/remix-run/react-router/edit/main/docs/index.md",
       });
     });
 
     it("detects /changelog", () => {
       expect(
-        buildDocPaths("/changelog", "changelog", LATEST, undefined),
+        buildDocPaths("/changelog", "changelog", LATEST, undefined, {
+          editRef: "main",
+        }),
       ).toEqual({
         slug: "CHANGELOG",
         githubPath: `https://raw.githubusercontent.com/remix-run/react-router/refs/tags/react-router@${LATEST}/CHANGELOG.md`,
+        githubEditPath:
+          "https://github.com/remix-run/react-router/edit/main/CHANGELOG.md",
       });
     });
 
     it("detects /changelog.md", () => {
       expect(
-        buildDocPaths("/changelog.md", "changelog.md", LATEST, undefined),
+        buildDocPaths("/changelog.md", "changelog.md", LATEST, undefined, {
+          editRef: "main",
+        }),
       ).toEqual({
         slug: "CHANGELOG",
         githubPath: `https://raw.githubusercontent.com/remix-run/react-router/refs/tags/react-router@${LATEST}/CHANGELOG.md`,
+        githubEditPath:
+          "https://github.com/remix-run/react-router/edit/main/CHANGELOG.md",
       });
     });
   });
@@ -151,6 +178,23 @@ describe("buildDocPaths", () => {
   });
 
   describe("semver tags", () => {
+    it("includes an edit path when the semver ref is the latest version", () => {
+      expect(
+        buildDocPaths(
+          `/${LATEST}/start/modes`,
+          `${LATEST}/start/modes`,
+          LATEST,
+          LATEST,
+          { editRef: "main" },
+        ),
+      ).toEqual({
+        slug: "docs/start/modes",
+        githubPath: `https://raw.githubusercontent.com/remix-run/react-router/refs/tags/react-router@${LATEST}/docs/start/modes.md`,
+        githubEditPath:
+          "https://github.com/remix-run/react-router/edit/main/docs/start/modes.md",
+      });
+    });
+
     it("uses refs/tags/react-router@X.Y.Z for post-changeset versions", () => {
       expect(
         buildDocPaths(

--- a/app/modules/gh-docs/.server/doc-url-parser.ts
+++ b/app/modules/gh-docs/.server/doc-url-parser.ts
@@ -42,6 +42,7 @@ export function buildDocPaths(
   splat: string,
   ref: string,
   refParam: string | undefined,
+  options: { editRef?: string } = {},
 ) {
   splat = splat.replace(/\.md$/, "");
   pathname = pathname.replace(/\.md$/, "");
@@ -58,7 +59,7 @@ export function buildDocPaths(
 
   return {
     slug,
-    ...generateGitHubPaths(ref, slug),
+    ...generateGitHubPaths(ref, slug, options.editRef),
   };
 }
 
@@ -89,19 +90,30 @@ function isRefBranch(ref: string): boolean {
 /**
  * Generates the correct GitHub raw URL based on the ref type
  * - For main/local: uses the ref directly
+ * - For main: exposes an edit URL
  * - For semantic versions: uses refs/tags/{version}
+ * - For refs with a GitHub edit ref: exposes an edit URL against that ref
  */
-function generateGitHubPaths(ref: string, slug: string) {
+function generateGitHubPaths(ref: string, slug: string, editRef?: string) {
   let baseUrl = "https://raw.githubusercontent.com/remix-run/react-router";
+  let editBaseUrl = "https://github.com/remix-run/react-router/edit";
 
   if (isRefBranch(ref)) {
     return {
       githubPath: `${baseUrl}/${ref}/${slug}.md`,
-      githubEditPath: `https://github.com/remix-run/react-router/edit/${ref}/${slug}.md`,
+      ...(ref === "main" && {
+        githubEditPath: `${editBaseUrl}/${ref}/${slug}.md`,
+      }),
     };
   }
 
-  return {
+  let paths: { githubPath: string; githubEditPath?: string } = {
     githubPath: `${baseUrl}/refs/tags/${fixupRefName(ref)}/${slug}.md`,
   };
+
+  if (editRef) {
+    paths.githubEditPath = `${editBaseUrl}/${editRef}/${slug}.md`;
+  }
+
+  return paths;
 }

--- a/app/pages/doc.tsx
+++ b/app/pages/doc.tsx
@@ -22,13 +22,16 @@ export async function loader({ url, params }: Route.LoaderArgs) {
   let splat = params["*"] ?? "";
   let tags = await getRepoTags();
   if (!tags) throw new Response("Cannot reach GitHub", { status: 503 });
-  let { ref, refParam } = resolveRef(splat, getLatestVersion(tags));
+  let latestVersion = getLatestVersion(tags);
+  let { ref, refParam } = resolveRef(splat, latestVersion);
+  let editRef = ref === latestVersion ? "main" : undefined;
 
   const { slug, githubPath, githubEditPath } = buildDocPaths(
     url.pathname,
     splat,
     ref,
     refParam,
+    { editRef },
   );
 
   // If the page is a markdown file, redirect to the raw GitHub file

--- a/app/pages/docs-layout.tsx
+++ b/app/pages/docs-layout.tsx
@@ -43,7 +43,7 @@ export async function loader({ url, params }: Route.LoaderArgs) {
 
   let [menu, header] = await Promise.all([
     getRepoDocsMenu(ref),
-    getHeaderData("en", ref, refParam),
+    getHeaderData("en", ref, tags, refParam),
   ]);
 
   return {


### PR DESCRIPTION
## Summary
- show GitHub edit links for the latest docs release by targeting main
- keep edit links hidden for older versioned docs
- avoid refetching repo tags in header data by reusing loader tags

## Testing
- pnpm test app/modules/gh-docs/.server/doc-url-parser.test.ts
- pnpm typecheck
- pnpm exec oxlint app/pages/doc.tsx app/pages/docs-layout.tsx app/components/docs-header/data.server.ts app/modules/gh-docs/.server/doc-url-parser.ts app/modules/gh-docs/.server/doc-url-parser.test.ts
- checked edit links on localhost:5173