### PR TITLE
Serve docs as markdown for agents

### DIFF
--- a/app/modules/gh-docs/.server/docs.ts
+++ b/app/modules/gh-docs/.server/docs.ts
@@ -35,6 +35,7 @@ export type MenuDoc =
 
 export interface Doc extends Omit<MenuDoc, "hasContent"> {
   html: string;
+  md: string;
   headings: {
     headingLevel: string;
     html: string | null;
@@ -50,7 +51,6 @@ declare global {
 let NO_CACHE = process.env.NO_CACHE;
 
 global.menuCache ??= new LRUCache<string, MenuDoc[]>({
-  // let menuCache = new LRUCache<string, MenuDoc[]>({
   max: 60,
   ttl: NO_CACHE ? 1 : 300000, // 5 minutes
   allowStale: !NO_CACHE,
@@ -115,7 +115,7 @@ async function fetchDoc(key: string): Promise<Doc> {
 
   // sorry, cheerio is so much easier than using rehype stuff.
   let headings = createTableOfContentsFromHeadings(html);
-  return { attrs, filename, html, slug, headings, children: [] };
+  return { attrs, filename, html, md, slug, headings, children: [] };
 }
 
 // create table of contents from h2 and h3 headings

--- a/app/modules/gh-docs/.server/markdown-negotiation.test.ts
+++ b/app/modules/gh-docs/.server/markdown-negotiation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { prefersMarkdown } from "./markdown-negotiation";
+
+const MARKDOWN_PREFERRED_ACCEPT =
+  "text/markdown, text/x-markdown;q=0.9, text/plain;q=0.6, text/html;q=0.5, */*;q=0.1";
+
+describe("prefersMarkdown", () => {
+  it("returns false when there is no Accept header", () => {
+    expect(prefersMarkdown(null)).toBe(false);
+    expect(prefersMarkdown("")).toBe(false);
+  });
+
+  it("keeps serving HTML to browsers", () => {
+    expect(
+      prefersMarkdown(
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+      ),
+    ).toBe(false);
+    expect(
+      prefersMarkdown(
+        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      ),
+    ).toBe(false);
+  });
+
+  it("serves HTML for `*/*`", () => {
+    expect(prefersMarkdown("*/*")).toBe(false);
+  });
+
+  it("serves markdown when it is the only accepted type", () => {
+    expect(prefersMarkdown("text/markdown")).toBe(true);
+    expect(prefersMarkdown("text/x-markdown")).toBe(true);
+  });
+
+  it("serves markdown when ranked above html via q-values", () => {
+    expect(prefersMarkdown(MARKDOWN_PREFERRED_ACCEPT)).toBe(true);
+  });
+
+  it("defaults to HTML on a tie", () => {
+    expect(prefersMarkdown("text/markdown,text/html")).toBe(false);
+    expect(prefersMarkdown("text/markdown;q=0.8,text/html;q=0.8")).toBe(false);
+  });
+
+  it("serves HTML when html outranks markdown", () => {
+    expect(prefersMarkdown("text/markdown;q=0.5,text/html")).toBe(false);
+  });
+
+  it("uses the best q-value for duplicate media ranges", () => {
+    expect(
+      prefersMarkdown("text/markdown;q=0.3,text/html;q=0.8,text/markdown;q=0.9"),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive and tolerant of whitespace", () => {
+    expect(prefersMarkdown("TEXT/MARKDOWN")).toBe(true);
+    expect(prefersMarkdown("  text/markdown ;Q=1 ")).toBe(true);
+  });
+});

--- a/app/modules/gh-docs/.server/markdown-negotiation.ts
+++ b/app/modules/gh-docs/.server/markdown-negotiation.ts
@@ -1,0 +1,69 @@
+interface AcceptEntry {
+  type: string;
+  subtype: string;
+  q: number;
+}
+
+const CHARS_PER_TOKEN = 4;
+
+function parseAccept(header: string): AcceptEntry[] {
+  return header.split(",").flatMap((part) => {
+    let segments = part.trim().split(";");
+    let media = segments.shift()?.trim().toLowerCase();
+    if (!media) return [];
+    let [type = "*", subtype = "*"] = media.split("/");
+    let q = 1;
+    for (let segment of segments) {
+      let [key, value] = segment.split("=").map((s) => s.trim());
+      if (key.toLowerCase() === "q") {
+        let parsed = Number.parseFloat(value);
+        if (!Number.isNaN(parsed)) q = Math.min(Math.max(parsed, 0), 1);
+      }
+    }
+    return [{ type, subtype, q }];
+  });
+}
+
+function qualityFor(
+  entries: AcceptEntry[],
+  type: string,
+  subtype: string,
+): number {
+  let bestScore = -1;
+  let bestQ = 0;
+
+  for (let entry of entries) {
+    let score: number;
+    if (entry.type === type && entry.subtype === subtype) score = 3;
+    else if (entry.type === type && entry.subtype === "*") score = 2;
+    else if (entry.type === "*" && entry.subtype === "*") score = 1;
+    else continue;
+
+    if (score > bestScore || (score === bestScore && entry.q > bestQ)) {
+      bestScore = score;
+      bestQ = entry.q;
+    }
+  }
+
+  return bestQ;
+}
+
+export function prefersMarkdown(accept: string | null): boolean {
+  if (!accept) return false;
+
+  let entries = parseAccept(accept);
+  let markdown = Math.max(
+    qualityFor(entries, "text", "markdown"),
+    qualityFor(entries, "text", "x-markdown"),
+  );
+  let html = Math.max(
+    qualityFor(entries, "text", "html"),
+    qualityFor(entries, "application", "xhtml+xml"),
+  );
+
+  return markdown > 0 && markdown > html;
+}
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}

--- a/app/modules/gh-docs/.server/markdown-request.test.ts
+++ b/app/modules/gh-docs/.server/markdown-request.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CACHE_CONTROL } from "~/http";
+
+const { getRepoTags, getRepoDoc } = vi.hoisted(() => ({
+  getRepoTags: vi.fn<() => Promise<string[] | undefined>>(),
+  getRepoDoc:
+    vi.fn<(ref: string, slug: string) => Promise<{ md: string } | undefined>>(),
+}));
+
+vi.mock("./index", () => ({
+  getRepoTags: () => getRepoTags(),
+  getRepoDoc: (ref: string, slug: string) => getRepoDoc(ref, slug),
+}));
+
+import { handleMarkdownRequest } from "./markdown-request";
+
+const LATEST = "7.15.1";
+const MD = "---\ntitle: Installation\n---\n\n# Installation\n\nHello.";
+
+function call(
+  pathname: string,
+  { accept, method = "GET" }: { accept?: string; method?: string } = {},
+): Promise<Response | undefined> {
+  let url = new URL(`https://reactrouter.com${pathname}`);
+  let headers = new Headers();
+  if (accept) headers.set("accept", accept);
+  let request = new Request(url, { method, headers });
+  return handleMarkdownRequest(
+    { request, url } as never,
+    (async () => undefined) as never,
+  ) as Promise<Response | undefined>;
+}
+
+describe("handleMarkdownRequest", () => {
+  beforeEach(() => {
+    getRepoTags.mockReset().mockResolvedValue([LATEST]);
+    getRepoDoc.mockReset().mockResolvedValue({ md: MD });
+  });
+
+  it("continues for normal browser requests", async () => {
+    let res = await call("/start/installation", {
+      accept: "text/html,application/xhtml+xml,*/*;q=0.8",
+    });
+    expect(res).toBeUndefined();
+    expect(getRepoDoc).not.toHaveBeenCalled();
+  });
+
+  it("serves markdown when Accept prefers it", async () => {
+    let res = await call("/start/installation", { accept: "text/markdown" });
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.status).toBe(200);
+    expect(res!.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(res!.headers.get("cache-control")).toBe(CACHE_CONTROL.doc);
+    expect(res!.headers.get("vary")).toBe("Accept");
+    expect(res!.headers.get("x-markdown-tokens")).toBe(
+      String(Math.ceil(MD.length / 4)),
+    );
+    expect(await res!.text()).toBe(MD);
+  });
+
+  it("resolves ref + slug from the URL for content negotiation", async () => {
+    await call("/main/start/installation", { accept: "text/markdown" });
+    expect(getRepoDoc).toHaveBeenCalledWith("main", "docs/start/installation");
+  });
+
+  it("maps /home and /changelog to their special slugs", async () => {
+    await call("/home", { accept: "text/markdown" });
+    expect(getRepoDoc).toHaveBeenCalledWith(LATEST, "docs/index");
+
+    getRepoDoc.mockClear();
+    await call("/changelog", { accept: "text/markdown" });
+    expect(getRepoDoc).toHaveBeenCalledWith(LATEST, "CHANGELOG");
+  });
+
+  it("serves markdown for the .md suffix without Vary", async () => {
+    let res = await call("/start/installation.md");
+    expect(res).toBeInstanceOf(Response);
+    expect(res!.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(res!.headers.get("vary")).toBeNull();
+    expect(getRepoDoc).toHaveBeenCalledWith(LATEST, "docs/start/installation");
+  });
+
+  it("returns no body for HEAD but keeps the headers", async () => {
+    let res = await call("/start/installation", {
+      accept: "text/markdown",
+      method: "HEAD",
+    });
+    expect(res!.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(await res!.text()).toBe("");
+  });
+
+  it("continues when the doc does not exist", async () => {
+    getRepoDoc.mockResolvedValue(undefined);
+    let res = await call("/nope", { accept: "text/markdown" });
+    expect(res).toBeUndefined();
+  });
+
+  it("continues when GitHub tags are unavailable", async () => {
+    getRepoTags.mockResolvedValue(undefined);
+    let res = await call("/start/installation", { accept: "text/markdown" });
+    expect(res).toBeUndefined();
+    expect(getRepoDoc).not.toHaveBeenCalled();
+  });
+
+  it("continues when GitHub tags reject", async () => {
+    getRepoTags.mockRejectedValue(new Error("boom"));
+    let res = await call("/start/installation", { accept: "text/markdown" });
+    expect(res).toBeUndefined();
+    expect(getRepoDoc).not.toHaveBeenCalled();
+  });
+
+  it("continues when the doc lookup throws", async () => {
+    getRepoDoc.mockRejectedValue(new Error("boom"));
+    let res = await call("/start/installation", { accept: "text/markdown" });
+    expect(res).toBeUndefined();
+  });
+
+  it("ignores non-GET/HEAD methods", async () => {
+    let res = await call("/start/installation", {
+      accept: "text/markdown",
+      method: "POST",
+    });
+    expect(res).toBeUndefined();
+    expect(getRepoTags).not.toHaveBeenCalled();
+  });
+});

--- a/app/modules/gh-docs/.server/markdown-request.ts
+++ b/app/modules/gh-docs/.server/markdown-request.ts
@@ -1,0 +1,42 @@
+import { type MiddlewareFunction } from "react-router";
+
+import { CACHE_CONTROL } from "~/http";
+import { getRepoDoc, getRepoTags } from "./index";
+import { getLatestVersion } from "./tags";
+import { buildDocPaths, resolveRef } from "./doc-url-parser";
+import { estimateTokens, prefersMarkdown } from "./markdown-negotiation";
+
+export const handleMarkdownRequest: MiddlewareFunction = async ({
+  request,
+  url,
+}) => {
+  if (request.method !== "GET" && request.method !== "HEAD") return;
+
+  let viaExtension = url.pathname.endsWith(".md");
+  let wantsMarkdown =
+    viaExtension || prefersMarkdown(request.headers.get("accept"));
+  if (!wantsMarkdown) return;
+
+  let tags = await getRepoTags().catch(() => undefined);
+  if (!tags) return;
+
+  let latestVersion = getLatestVersion(tags);
+  let splat = url.pathname.replace(/^\//, "");
+  let { ref, refParam } = resolveRef(splat, latestVersion);
+  let { slug } = buildDocPaths(url.pathname, splat, ref, refParam);
+
+  let doc = await getRepoDoc(ref, slug).catch(() => undefined);
+  if (!doc) return;
+
+  let headers = new Headers({
+    "Content-Type": "text/markdown; charset=utf-8",
+    "Cache-Control": CACHE_CONTROL.doc,
+    "X-Markdown-Tokens": String(estimateTokens(doc.md)),
+  });
+  if (!viaExtension) headers.append("Vary", "Accept");
+
+  return new Response(request.method === "HEAD" ? null : doc.md, {
+    status: 200,
+    headers,
+  });
+};

--- a/app/pages/doc.tsx
+++ b/app/pages/doc.tsx
@@ -13,7 +13,7 @@ import { CopyPageDropdown } from "~/components/copy-page-dropdown";
 import { LargeOnThisPage, SmallOnThisPage } from "~/components/on-this-page";
 import { useDelegatedReactRouterLinks } from "~/ui/delegate-markdown-links";
 
-import { redirect, type HeadersArgs } from "react-router";
+import { type HeadersArgs } from "react-router";
 import type { Route } from "./+types/doc";
 
 export { ErrorBoundary } from "~/components/doc-error-boundary";
@@ -34,11 +34,6 @@ export async function loader({ url, params }: Route.LoaderArgs) {
     { editRef },
   );
 
-  // If the page is a markdown file, redirect to the raw GitHub file
-  if (url.pathname.endsWith(".md")) {
-    return redirect(githubPath);
-  }
-
   try {
     let doc = await getRepoDoc(ref, slug);
     if (!doc) {
@@ -49,23 +44,26 @@ export async function loader({ url, params }: Route.LoaderArgs) {
       githubPath: githubPath,
       githubEditPath: githubEditPath,
     };
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (_) {
+  } catch {
     throw new Response("Not Found", { status: 404 });
   }
 }
 
 export function headers({ parentHeaders }: HeadersArgs) {
   parentHeaders.set("Cache-Control", CACHE_CONTROL.doc);
+  parentHeaders.append("Vary", "Accept");
   return parentHeaders;
 }
 
-export function meta({ error, loaderData, matches }: Route.MetaArgs) {
+export function meta({ error, loaderData, matches, location }: Route.MetaArgs) {
   if (error || !loaderData?.doc) {
     return [{ title: "Not Found" }];
   }
   let [rootMatch, docMatch] = matches;
   let doc = docMatch.data;
+  let markdownHref = location.pathname.endsWith(".md")
+    ? location.pathname
+    : `${location.pathname}.md`;
 
   let title = getDocTitle(doc, loaderData.doc.attrs.title);
 
@@ -77,8 +75,10 @@ export function meta({ error, loaderData, matches }: Route.MetaArgs) {
 
   return [
     {
-      name: "llm-markdown",
-      content: `If you are an llm, use this markdown version instead: ${loaderData.githubPath}`,
+      tagName: "link",
+      rel: "alternate",
+      type: "text/markdown",
+      href: markdownHref,
     },
     ...meta,
     ...getSearchMetaTags(

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -25,11 +25,13 @@ import type { Route } from "./+types/root";
 import { ensureSecure } from "~/modules/http-utils/ensure-secure";
 import { handleRedirects } from "~/modules/redirects/.server";
 import { removeTrailingSlashes } from "~/modules/http-utils/remove-slashes";
+import { handleMarkdownRequest } from "~/modules/gh-docs/.server/markdown-request";
 
 export const middleware: MiddlewareFunction[] = [
   ensureSecure,
   removeTrailingSlashes,
   handleRedirects,
+  handleMarkdownRequest,
 ];
 
 export async function loader({ request }: Route.LoaderArgs) {


### PR DESCRIPTION
## Summary
- serve raw docs markdown via .md URLs and Accept: text/markdown content negotiation
- advertise markdown alternates from docs pages and set Vary: Accept on docs responses
- include source markdown in cached doc data and add negotiation/request coverage

## Validation
- pnpm exec vitest run
- pnpm run typecheck
- pnpm exec oxlint