### PR TITLE
Add redirects for 7.16.0 future flag warnings

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -83,7 +83,7 @@
 /en/main/route/error-element                 https://api.reactrouter.com/v7/interfaces/react_router.NonIndexRouteObject.html#errorElement
 /en/main/route/hydrate-fallback-element      https://api.reactrouter.com/v7/interfaces/react_router.NonIndexRouteObject.html#hydrateFallbackElement
 /en/main/route/lazy                          https://api.reactrouter.com/v7/interfaces/react_router.LazyRouteFunction.html
-/en/main/route/loader                        https://api.reactrouter.com/v7/types/react_router.LoaderFunction.html   
+/en/main/route/loader                        https://api.reactrouter.com/v7/types/react_router.LoaderFunction.html
 /en/main/route/should-revalidate             https://api.reactrouter.com/v7/interfaces/react_router.ShouldRevalidateFunction.html
 
 # catchall for remaining v6 docs with lang prefix
@@ -101,3 +101,6 @@
 /core/* https://v5.reactrouter.com/core/*
 /web/* https://v5.reactrouter.com/web/*
 /native/* https://v5.reactrouter.com/native/*
+
+# v7 future flag warnings
+/upgrading/future-flags /7.16.0/upgrading/future


### PR DESCRIPTION
We used the old version of this UR in our console warnings :/

```
Future Flag Warning: Route middleware support is changing in React Router v8.
     You can use the `future.v8_middleware` flag to opt in early.
     -> https://reactrouter.com/upgrading/future-flags#v8_middleware
```

This adds a redirect to land those links at the right spot, and we'll fix the warnings in 7.16.1