### PR TITLE
Update robots directives for legacy docs discovery

### DIFF
--- a/app/components/docs-header/data.server.test.ts
+++ b/app/components/docs-header/data.server.test.ts
@@ -12,6 +12,7 @@ describe("getHeaderData", () => {
       apiDocsRef: "v7",
       docSearchVersion: "v7",
       shouldIndexDocPage: true,
+      shouldFollowDocPageLinks: true,
     });
   });
 
@@ -31,17 +32,41 @@ describe("getHeaderData", () => {
       apiDocsRef: "v8",
       docSearchVersion: "v8",
       shouldIndexDocPage: true,
+      shouldFollowDocPageLinks: true,
     });
   });
 
-  it("keeps previous v7 docs searchable without indexing them as current", () => {
+  it("follows latest previous-major docs without indexing them", () => {
     expect(
-      getHeaderData("en", "7.9.6", ["8.0.0", "7.9.6", "6.30.1"], "7.9.6"),
+      getHeaderData(
+        "en",
+        "7.18.0",
+        ["8.0.0", "7.18.0", "7.17.0", "6.30.1"],
+        "7.18.0",
+      ),
     ).toMatchObject({
       hasAPIDocs: true,
       apiDocsRef: "v7",
       docSearchVersion: "v7",
       shouldIndexDocPage: false,
+      shouldFollowDocPageLinks: true,
+    });
+  });
+
+  it("keeps older previous-major docs nofollow", () => {
+    expect(
+      getHeaderData(
+        "en",
+        "7.17.0",
+        ["8.0.0", "7.18.0", "7.17.0", "6.30.1"],
+        "7.17.0",
+      ),
+    ).toMatchObject({
+      hasAPIDocs: true,
+      apiDocsRef: "v7",
+      docSearchVersion: "v7",
+      shouldIndexDocPage: false,
+      shouldFollowDocPageLinks: false,
     });
   });
 
@@ -53,10 +78,23 @@ describe("getHeaderData", () => {
       apiDocsRef: "v8",
       docSearchVersion: "v8",
       shouldIndexDocPage: false,
+      shouldFollowDocPageLinks: false,
     });
   });
 
-  it("keeps v6 releases searchable as legacy docs", () => {
+  it("follows latest v6 releases for DocSearch discovery", () => {
+    expect(
+      getHeaderData("en", "6.30.1", ["8.0.0", "7.9.6", "6.30.1"], "6.30.1"),
+    ).toMatchObject({
+      hasAPIDocs: false,
+      apiDocsRef: null,
+      docSearchVersion: "v6",
+      shouldIndexDocPage: false,
+      shouldFollowDocPageLinks: true,
+    });
+  });
+
+  it("keeps older v6 releases nofollow", () => {
     expect(
       getHeaderData("en", "6.28.0", ["8.0.0", "7.9.6", "6.30.1"], "6.28.0"),
     ).toMatchObject({
@@ -64,6 +102,7 @@ describe("getHeaderData", () => {
       apiDocsRef: null,
       docSearchVersion: "v6",
       shouldIndexDocPage: false,
+      shouldFollowDocPageLinks: false,
     });
   });
 });

--- a/app/components/docs-header/data.server.ts
+++ b/app/components/docs-header/data.server.ts
@@ -42,8 +42,15 @@ export function getHeaderData(
         ? `v${latestMajor}`
         : null;
 
-  // Search engines should only crawl root URLs, not versioned URLs.
+  // Search engines should only index root URLs. Versioned URLs for the latest
+  // release of each previous major should be followable for DocSearch discovery.
   let shouldIndexDocPage = refParam === undefined;
+  let shouldFollowDocPageLinks =
+    shouldIndexDocPage ||
+    (refParam !== undefined &&
+      !isLatest &&
+      githubRefMajor !== undefined &&
+      versions.some((version) => semver.eq(version, githubRef)));
 
   // Set the version for docsearch to use as a facet filter so that the search
   // results are context aware.
@@ -63,5 +70,6 @@ export function getHeaderData(
     apiDocsRef,
     docSearchVersion,
     shouldIndexDocPage,
+    shouldFollowDocPageLinks,
   } as const;
 }

--- a/app/pages/doc.tsx
+++ b/app/pages/doc.tsx
@@ -85,6 +85,7 @@ export function meta({ error, loaderData, matches, location }: Route.MetaArgs) {
       rootMatch.loaderData.isProductionHost,
       doc.header.docSearchVersion,
       doc.header.shouldIndexDocPage,
+      doc.header.shouldFollowDocPageLinks,
     ),
   ];
 }

--- a/app/pages/docs-v6-index.tsx
+++ b/app/pages/docs-v6-index.tsx
@@ -23,7 +23,8 @@ export function meta({ matches }: Route.MetaArgs) {
     openGraph: { title },
   });
 
-  let { docSearchVersion, shouldIndexDocPage } = doc.header;
+  let { docSearchVersion, shouldIndexDocPage, shouldFollowDocPageLinks } =
+    doc.header;
 
   return [
     ...meta,
@@ -31,6 +32,7 @@ export function meta({ matches }: Route.MetaArgs) {
       rootMatch.loaderData.isProductionHost,
       docSearchVersion,
       shouldIndexDocPage,
+      shouldFollowDocPageLinks,
     ),
   ];
 }

--- a/app/ui/meta.ts
+++ b/app/ui/meta.ts
@@ -21,8 +21,11 @@ export function getSearchMetaTags(
   isProductionHost: boolean,
   docSearchVersion: HeaderData["docSearchVersion"],
   shouldIndexDocPage: HeaderData["shouldIndexDocPage"],
+  shouldFollowDocPageLinks: HeaderData["shouldFollowDocPageLinks"],
 ) {
-  let robots = "noindex,nofollow";
+  let robots = shouldFollowDocPageLinks
+    ? "noindex,follow"
+    : "noindex,nofollow";
   if (isProductionHost && shouldIndexDocPage) {
     robots = "index,follow";
   }


### PR DESCRIPTION
## Summary
- add separate follow behavior for DocSearch-discoverable docs pages
- allow latest previous-major docs to emit `noindex,follow` while older versioned docs remain `noindex,nofollow`
- cover latest/older legacy version behavior in header data tests

## Testing
- pnpm exec vitest run app/components/docs-header/data.server.test.ts
- pnpm exec oxlint
- pnpm exec tsc --noEmit