### PR TITLE
Support diff markers in docs code blocks

### DIFF
--- a/app/modules/gh-docs/.server/md.test.ts
+++ b/app/modules/gh-docs/.server/md.test.ts
@@ -1,0 +1,47 @@
+import { load } from "cheerio";
+import { describe, expect, it } from "vitest";
+
+import { processMarkdown } from "./md";
+
+describe("processMarkdown", () => {
+  it("supports diff markers on syntax-highlighted code blocks", async () => {
+    let { html } = await processMarkdown(`
+\`\`\`tsx diff
+-import { OldLink } from "react-router";
++import { NewLink } from "react-router";
+
+export default function App() {
+- let oldPath = "/old";
++ let newPath = "/new";
+
+  return (
+    <div>
+-     <OldLink to={oldPath} />
++     <NewLink to={newPath} />
+    </div>
+    );
+}
+\`\`\`
+`);
+    let $ = load(html);
+    let lines = $(".codeblock-line").toArray();
+
+    expect($("pre").attr("data-lang")).toBe("tsx");
+    expect($("pre").attr("data-diff")).toBe("");
+    expect(lines).toHaveLength(14);
+    expect($(lines[0]).attr("data-remove")).toBe("");
+    expect($(lines[0]).text()).toMatch(/^import .*OldLink/);
+    expect($(lines[1]).attr("data-add")).toBe("");
+    expect($(lines[1]).text()).toMatch(/^import .*NewLink/);
+    expect($(lines[3]).attr("data-add")).toBeUndefined();
+    expect($(lines[3]).text()).toMatch(/^export default/);
+    expect($(lines[4]).attr("data-remove")).toBe("");
+    expect($(lines[4]).text()).toMatch(/^  let oldPath/);
+    expect($(lines[5]).attr("data-add")).toBe("");
+    expect($(lines[5]).text()).toMatch(/^  let newPath/);
+    expect($(lines[9]).attr("data-remove")).toBe("");
+    expect($(lines[9]).text()).toMatch(/^      <OldLink/);
+    expect($(lines[10]).attr("data-add")).toBe("");
+    expect($(lines[10]).text()).toMatch(/^      <NewLink/);
+  });
+});

--- a/app/modules/gh-docs/.server/md.ts
+++ b/app/modules/gh-docs/.server/md.ts
@@ -153,6 +153,7 @@ async function loadPlugins() {
           nodeProperties,
           removedLines,
           startingLineNumber,
+          usesDiffMarkers,
           usesLineNumbers,
         } = getCodeBlockMeta();
 
@@ -160,6 +161,28 @@ async function loadPlugins() {
         return SKIP;
 
         async function highlightNodes() {
+          let diffLineMarkers: Array<"add" | "remove" | undefined> = [];
+
+          if (usesDiffMarkers) {
+            code = code
+              .split(/\r?\n/)
+              .map((line) => {
+                if (line[0] === "+") {
+                  diffLineMarkers.push("add");
+                  return `${line[1] === " " ? " " : ""}${line.slice(1)}`;
+                }
+
+                if (line[0] === "-") {
+                  diffLineMarkers.push("remove");
+                  return `${line[1] === " " ? " " : ""}${line.slice(1)}`;
+                }
+
+                diffLineMarkers.push(undefined);
+                return line;
+              })
+              .join("\n");
+          }
+
           let tokens = getThemedTokens({ code, language });
           let children = tokens.map(
             (lineTokens, zeroBasedLineNumber): Hast.Element => {
@@ -190,12 +213,19 @@ async function loadPlugins() {
                 value: "\n",
               });
 
-              let isDiff = addedLines.length > 0 || removedLines.length > 0;
+              let isDiff =
+                usesDiffMarkers ||
+                addedLines.length > 0 ||
+                removedLines.length > 0;
               let diffLineNumber = startingLineNumber - 1;
               let lineNumber = zeroBasedLineNumber + startingLineNumber;
               let highlightLine = highlightLines?.includes(lineNumber);
-              let removeLine = removedLines.includes(lineNumber);
-              let addLine = addedLines.includes(lineNumber);
+              let addLine =
+                addedLines.includes(lineNumber) ||
+                diffLineMarkers[zeroBasedLineNumber] === "add";
+              let removeLine =
+                removedLines.includes(lineNumber) ||
+                diffLineMarkers[zeroBasedLineNumber] === "remove";
               if (!removeLine) {
                 diffLineNumber++;
               }
@@ -269,6 +299,7 @@ async function loadPlugins() {
           let addedLines = parseLineHighlights(metaParams.get("add"));
           let removedLines = parseLineHighlights(metaParams.get("remove"));
           let highlightLines = parseLineHighlights(metaParams.get("lines"));
+          let usesDiffMarkers = metaParams.has("diff") && language !== "diff";
           let startValNum = metaParams.has("start")
             ? Number(metaParams.get("start"))
             : 1;
@@ -289,6 +320,7 @@ async function loadPlugins() {
             nodeProperties,
             removedLines,
             startingLineNumber,
+            usesDiffMarkers,
             usesLineNumbers,
           };
         }

--- a/app/styles/docs.css
+++ b/app/styles/docs.css
@@ -312,6 +312,40 @@
     @apply relative block pr-4;
   }
 
+  & .codeblock-line[data-add] {
+    color: var(--base0B);
+    background-color: color-mix(
+      in oklab,
+      theme("colors.green.400") 20%,
+      transparent
+    );
+
+    &:where(.dark) {
+      background-color: color-mix(
+        in oklab,
+        theme("colors.green.400") 40%,
+        transparent
+      );
+    }
+  }
+
+  & .codeblock-line[data-remove] {
+    color: var(--base08);
+    background-color: color-mix(
+      in oklab,
+      theme("colors.red.400") 20%,
+      transparent
+    );
+
+    &:where(.dark) {
+      background-color: color-mix(
+        in oklab,
+        theme("colors.red.400") 40%,
+        transparent
+      );
+    }
+  }
+
   & :not(pre) > code {
     @apply rounded bg-gray-100/50 px-1.5 pb-0.5 pt-px text-sm text-gray-700 dark:bg-gray-800/50;
   }
@@ -374,6 +408,23 @@
     [data-line-number]::before {
     content: attr(data-line-number);
     @apply mr-6 inline-block w-8 pl-0 text-right text-gray-300 dark:text-gray-600;
+  }
+
+  &
+    pre[data-diff][data-line-numbers="true"]:not(
+      [data-lang="bash"],
+      [data-lang="sh"]
+    ) {
+    & .codeblock-line::before {
+      content: attr(data-line-number) "  ";
+      @apply mr-4 w-10;
+    }
+    & .codeblock-line[data-remove]::before {
+      content: attr(data-line-number) " -";
+    }
+    & .codeblock-line[data-add]::before {
+      content: attr(data-line-number) " +";
+    }
   }
 
   & pre[data-good] {


### PR DESCRIPTION
Line diffs are hard ... no longer.

We used to use `tsx add=[] remove=[]` code fences and manually specify the lines to highlight as added/removed.  This had the benefit of retaining syntax highlighting but manually managing the line numbers was annoying/tedious.

At some point, I'm unsure when, it seems like we shifted to just normal `diff` code fences.  This does automatic line add/remove identification but loses syntax highlighting and makes background line highlighting harder.

Enter `tsx diff` - the best of both worlds.  Keeps syntax highlighting, but auto-detects the added/removed based on the diff syntax and displays accordingly.

In:

<img width="591" height="195" alt="Screenshot 2026-06-30 at 12 17 05 PM" src="https://github.com/user-attachments/assets/48da63d7-3106-437c-8b00-745afcdb25a3" />

Out:

<img width="830" height="232" alt="Screenshot 2026-06-30 at 12 16 41 PM" src="https://github.com/user-attachments/assets/04fa2f4f-8337-4e77-9da8-b2ac63e4f76c" />

Comparing the old and the new:

<img width="855" height="875" alt="Screenshot 2026-06-30 at 12 24 32 PM" src="https://github.com/user-attachments/assets/d55b8cab-f3b8-449f-93b0-1c6355c0b1c5" />

<img width="866" height="1010" alt="Screenshot 2026-06-30 at 12 24 42 PM" src="https://github.com/user-attachments/assets/a4134d2e-9272-411f-aa41-323697727799" />

RR Sibling PR: https://github.com/remix-run/react-router/pull/15261
